### PR TITLE
fix(middleware/passport.js): token expiration: github issues #47

### DIFF
--- a/middleware/passport.js
+++ b/middleware/passport.js
@@ -33,7 +33,7 @@ module.exports = function (passport, app) {
             if (!user || !user.validPassword(password)) {
               return done(null, false)
             } else {
-              const expires = moment().add(1, 'days').valueOf()
+              const expires = moment().add(1, 'days').unix()
               user.token = jwt.encode(
                 {
                   iss: user.id,


### PR DESCRIPTION
Inside the passport strategy, replace moment#valueOf by moment#unix function to have an expiration time in seconds

https://momentjs.com/docs/#/displaying/unix-timestamp/