### PR TITLE
fix(authentification.js): only jwt.decode should verify token validity

### DIFF
--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -6,16 +6,17 @@ exports.isAuthenticated = async (req, res, next) => {
   const token = exports.retrieveToken(req)
 
   if (token) {
+    let decoded = null;
+
     try {
-      const decoded = jwt.decode(token, 'UFOOD_TOKEN_SECRET')
-
-      if (decoded.exp <= Date.now()) {
-        return res.status(401).send({
-          errorCode: 'ACCESS_DENIED',
-          message: 'Access token is expired'
-        })
-      }
-
+      decoded = jwt.decode(token, 'UFOOD_TOKEN_SECRET')
+    } catch (err) {
+      return res.status(401).send({
+        errorCode: 'ACCESS_DENIED',
+        message: err.toString()
+      })
+    }
+    try {
       const user = await UserModel.findOne({ _id: decoded.iss })
       if (user) {
         req.user = user


### PR DESCRIPTION
Seul le module jwt-simple doit être responsable de la vérification de la validité du token:

[jwt-simple code source](https://github.com/hokaccha/node-jwt-simple/blob/master/lib/jwt.js)

- Suppression de la logique de vérification basé sur le temps d'expiration en milliseconds
- Ajout d'un bloc de try catch pour renvoyer l'erreur du token à l'utilisateur